### PR TITLE
Remove attempt to build a MacOS binary

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,7 +6,7 @@ on:
       - created
 
 jobs:
-  build_and_upload_linux_binary:
+  build_and_upload_binary:
     runs-on: ubuntu-latest
     container:
       image: crystallang/crystal:latest-alpine
@@ -22,19 +22,4 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./bin/skedjewel
           asset_name: skedjewel-${{ github.event.release.tag_name }}-linux
-          asset_content_type: binary/octet-stream
-  build_and_upload_macos_binary:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: shards build --production --release --no-debug
-      - name: Upload
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./bin/skedjewel
-          asset_name: skedjewel-${{ github.event.release.tag_name }}-macos
           asset_content_type: binary/octet-stream


### PR DESCRIPTION
It fails with `shards: command not found` (presumably because the `macos-latest` image doesn't have Crystal installed).