### PR TITLE
Build for linux with `--static` flag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: shards build --production --release --no-debug
+        run: shards build --production --release --no-debug --static
       - name: Upload
         uses: actions/upload-release-asset@v1.0.1
         env:


### PR DESCRIPTION
Without this, we are getting `bash: ./bin/skedjewel: No such file or directory` when attempting to deploy the david_runger app.