### PR TITLE
Implement Redis lock

### DIFF
--- a/src/lock_manager.cr
+++ b/src/lock_manager.cr
@@ -1,8 +1,8 @@
 class Skedjewel::LockManager
-  def lock(_resource_key, _lock_time)
-  end
-
-  def locked?(_resource_key)
-    false
+  def with_lock(resource_key, lock_time_in_seconds)
+    lock_obtained =
+      Skedjewel.app_redis.set(resource_key, "locked", lock_time_in_seconds, nil, true, nil)
+    #                 def set(key,          value,    ex,                   px,  nx,   xx)
+    yield if lock_obtained
   end
 end

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -35,14 +35,14 @@ class Skedjewel::Runner
     @lock_manager ||= Skedjewel::LockManager.new
   end
 
+  def seconds_until_next_minute(time)
+    seconds_into_minute = time.second.to_f + (time.to_unix_f % 1.0)
+    60.0 - seconds_into_minute
+  end
+
   private def execute_tasks
     @tasks.each do |task|
       task.run if task.should_run?
     end
-  end
-
-  private def seconds_until_next_minute(time)
-    seconds_into_minute = time.second.to_f + (time.to_unix_f % 1.0)
-    60.0 - seconds_into_minute
   end
 end


### PR DESCRIPTION
This will prevent tasks from being executed twice within the same minute when, for example, there are two `skedjewel` processes running (which happens during deploys).