### PR TITLE
Add `release-tag` to release action options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           files: skedjewel-${{  github.ref_name }}-darwin
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{  github.ref_name }}

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 class Skedjewel
-  VERSION = "0.0.6.alpha1"
+  VERSION = "0.0.6.alpha2"
 end


### PR DESCRIPTION
We were getting an error stating "Cannot upload assets for release which is being undefined"; let's see if this fixes it.