### PR TITLE
Specify AButler/upload-release-assets to use v2 rather than v2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Move and rename
         run: mv bin/skedjewel ./skedjewel-${{  github.ref_name }}-linux
       - name: Release
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v2
         with:
           files: skedjewel-${{  github.ref_name }}-linux
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
       - name: Move and rename
         run: mv bin/skedjewel ./skedjewel-${{  github.ref_name }}-darwin
       - name: Release
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v2
         with:
           files: skedjewel-${{  github.ref_name }}-darwin
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 class Skedjewel
-  VERSION = "0.0.6"
+  VERSION = "0.0.7.alpha1"
 end


### PR DESCRIPTION
I'm hoping that this will use the [2.0.1 release][0].

[0]: https://github.com/AButler/upload-release-assets/releases/tag/v2.0.1