### PR TITLE
Specify macos-11 build image for building MacOS binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_upload_macos_binary:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
       - name: Install Crystal


### PR DESCRIPTION
Using macos-latest generates a warning about how it's going to switch to macos-12 soon. The warning is annoying (although appreciated), but, more importantly, I'm still on macos-11, so let's keep using that.