### PR TITLE
Fix deprecation warning about 'sleep' with a Number argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- Change deprecated `sleep(Number)` to `sleep(Time::Span)`.
+- Change `sleep` padding from 100 ms to 1 ms.
+
 # v0.0.11 - 2024-02-06
 - Only log and exit once (#45)
 

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -3,6 +3,8 @@ require "./lock_manager"
 require "./version"
 
 class Skedjewel::Runner
+  NANOSECONDS_IN_A_SECOND = 1_000_000_000
+
   getter :tasks
 
   @@began_exit_process = false
@@ -40,7 +42,16 @@ class Skedjewel::Runner
 
     loop do
       execute_tasks
-      sleep(seconds_until_next_minute(Time.local) + 0.1)
+
+      sleep(
+        Time::Span.new(
+          nanoseconds:
+            seconds_to_nanoseconds(
+              seconds_until_next_minute(Time.local) +
+                0.001, # Add a millisecond to ensure we go into the next minute.
+            ),
+        )
+      )
     end
   end
 
@@ -57,5 +68,9 @@ class Skedjewel::Runner
     @tasks.each do |task|
       task.run if task.should_run?
     end
+  end
+
+  private def seconds_to_nanoseconds(seconds)
+    (seconds * NANOSECONDS_IN_A_SECOND).to_i64
   end
 end


### PR DESCRIPTION
Instead, we are now to use a `Time::Span` object to represent the time. I don't like this new change very much (as it makes the code more complex and difficult to read), but I am guessing there's some good reason for it.

While touching this code / slightly relatedly (since apparently these sleeps have nanosecond precision...), I am also changing the sleep padding from 100 ms to just 1 ms. This will make the jobs execute more nearly right on the minute.