### PR TITLE
Add script to build executable for local use

### DIFF
--- a/bin/local/build
+++ b/bin/local/build
@@ -3,7 +3,7 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 docker run \
-  --rm -it \
+  --rm \
   -v $(pwd):/workspace \
   -w /workspace \
   crystallang/crystal:latest-alpine \

--- a/bin/local/build
+++ b/bin/local/build
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+docker run \
+  --rm -it \
+  -v $(pwd):/workspace \
+  -w /workspace \
+  crystallang/crystal:latest-alpine \
+  shards build \
+    --production \
+    --release \
+    --static \
+    --no-debug


### PR DESCRIPTION
When building on my machine via `shards build --production --release
--no-debug --static` I was getting warnings like this:

/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/libcrypto.a(libcrypto-lib-dso_dlfcn.o): in function \`dlfcn_globallookup':
(.text+0x11): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: _main.o3.o: in function \`*TCPSocket::new:dns_timeout:connect_timeout<String, Int32, (Time::Span | Nil), (Time::Span | Nil)>:TCPSocket':
main_module:(.text+0x8a3f5): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/libcrypto.a(libcrypto-lib-bio_sock.o): in function \`BIO_gethostbyname':
(.text+0x81): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

Building via the alpine-based Crystal Docker image avoids these warnings (I guess (according to Perplexity) by using musl libc rather than glibc for the compilation).

Thanks to Perplexity for this suggestion (private link): https://www.perplexity.ai/search/when-i-build-my-crystal-projec-D8FMo9ZhS36TVUmkUPa.TQ