### PR TITLE
Add '-it' flags to docker command for local build

### DIFF
--- a/bin/local/build
+++ b/bin/local/build
@@ -4,6 +4,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 docker run \
   --rm \
+  -it \
   -v $(pwd):/workspace \
   -w /workspace \
   crystallang/crystal:latest-alpine \


### PR DESCRIPTION
Without these, the build cannot be interrupted (quickly / without weird errors) with Ctrl+C.

Also, with these flags, the output is colored and formatted more prettily.