### PR TITLE
Update to Sidekiq 8 timestamp format (epoch milliseconds, not floats)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.0.15 - 2025-03-07
+- Update to Sidekiq 8 timestamp format (epoch milliseconds, not floats).
+
 # v0.0.14 - 2025-01-22
 - Change deprecated `sleep(Number)` to `sleep(Time::Span)`.
 - Change `sleep` padding from 100 ms to 1 ms.

--- a/src/task.cr
+++ b/src/task.cr
@@ -29,7 +29,7 @@ class Skedjewel::Task
 
   private def job_hash
     # https://github.com/mperham/sidekiq/wiki/FAQ#how-do-i-push-a-job-to-sidekiq-without-ruby
-    current_time = Time.local.to_unix_f
+    current_time = (Time.local.to_unix_f * 1_000).round
     {
       "class"       => @job_name,
       "queue"       => "default",

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 class Skedjewel
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end


### PR DESCRIPTION
> **WARNING** The `created_at`, `enqueued_at`, `failed_at` and `retried_at` attributes are now stored as epoch milliseconds, rather than epoch floats. This is meant to avoid precision issues with JSON and JavaScript's 53-bit Floats. Example: `"created_at" => 1234567890.123456` -> `"created_at" => 1234567890123`.

-- https://github.com/sidekiq/sidekiq/blob/main/Changes.md#800

Somewhat surprisingly, this doesn't actually seem to affect anything?, but we probably should try to provide appropriate timestamp values.