### PR TITLE
Support scheduling a job every X minutes [SKED-6]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.0.16 - 2025-03-15
+- Support scheduling a job every X minutes.
+
 # v0.0.15 - 2025-03-07
 - Update to Sidekiq 8 timestamp format (epoch milliseconds, not floats).
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ config:
 jobs:
   DataMonitors::Launcher: '**:07' # hourly at 7 minutes after
   SendLogReminderEmails: '**:**' # every minute
+  CapturePgHeroQueryStats: '**:%5' # every 5 minutes
   TruncateTables: '04:58' # daily at 4:58am Central Time
 ```
 

--- a/spec/schedule_spec.cr
+++ b/spec/schedule_spec.cr
@@ -64,6 +64,34 @@ Spectator.describe Skedjewel::Schedule do
           end
         end
       end
+
+      context "when the schedule string is '**:%5'" do
+        let(schedule_string) { "**:%5" }
+
+        context "when the checked time is UTC 00:15:29" do
+          let(time) { Time.utc(2025, 3, 15, 0, 15, 29) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is UTC 13:25:48" do
+          let(time) { Time.utc(2025, 3, 15, 13, 25, 48) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is UTC 13:26:48" do
+          let(time) { Time.utc(2025, 3, 15, 13, 26, 48) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+      end
     end
 
     context "when the schedule time zone has a positive UTC offset" do

--- a/src/schedule.cr
+++ b/src/schedule.cr
@@ -1,4 +1,6 @@
 class Skedjewel::Schedule
+  MODULUS_REGEX = /^%(?<modulus>\d{1,2})$/
+
   @schedule_hour : String
   @minute : String
   @utc_scheduled_integer_hour : Int32 | Nil
@@ -17,7 +19,18 @@ class Skedjewel::Schedule
   end
 
   private def minute_match?(time)
-    @minute == "**" || time.minute == integer_minute
+    if @minute == "**"
+      true
+    elsif @schedule_hour == "**" && @minute.matches?(MODULUS_REGEX)
+      minute_modulo_match?(time)
+    else
+      time.minute == integer_minute
+    end
+  end
+
+  private def minute_modulo_match?(time)
+    minute_modulus = @minute.match!(MODULUS_REGEX)["modulus"].to_i
+    (time.minute % minute_modulus) == 0
   end
 
   private def utc_scheduled_integer_hour

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 class Skedjewel
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end


### PR DESCRIPTION
[PgHero](https://github.com/ankane/pghero) (which I am going to implement in `david_runger`) says that it should be scheduled to run every 5 minutes: https://github.com/ankane/pghero/blob/master/guides/Rails.md#historical-query-stats

This change adds support for syntax like this to run a job every 5 minutes:

```yml
CapturePgHeroQueryStats: '**:%5' # every 5 minutes
```