### PR TITLE
Support minute modulus even if hour is not "**" [SKED-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Support scheduling a job every X hours.
+- Support minute modulus even if hour is not `**`.
 
 ### Docs
 - Make README release title headings h2s (not h1s).

--- a/spec/schedule_spec.cr
+++ b/spec/schedule_spec.cr
@@ -129,6 +129,78 @@ Spectator.describe Skedjewel::Schedule do
           end
         end
       end
+
+      context "when the schedule string is '02:%5'" do
+        let(schedule_string) { "02:%5" }
+
+        context "when the checked time is local time 02:30" do
+          let(time) { Time.local(2025, 3, 16, 2, 30, 0, location: location) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is local time 22:35" do
+          let(time) { Time.local(2025, 3, 16, 22, 35, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+
+        context "when the checked time is local time 02:31" do
+          let(time) { Time.local(2025, 3, 16, 2, 31, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+
+        context "when the checked time is local time 03:30" do
+          let(time) { Time.local(2025, 3, 16, 3, 30, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+      end
+
+      context "when the schedule string is '%4:%10'" do
+        let(schedule_string) { "%4:%10" }
+
+        context "when the checked time is local time 08:50" do
+          let(time) { Time.local(2025, 3, 16, 8, 50, 1, location: location) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is local time 00:00" do
+          let(time) { Time.local(2025, 3, 16, 0, 0, 0, location: location) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is local time 00:05" do
+          let(time) { Time.local(2025, 3, 16, 0, 5, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+
+        context "when the checked time is local time 02:00" do
+          let(time) { Time.local(2025, 3, 16, 2, 0, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+      end
     end
 
     context "when the schedule time zone has a positive UTC offset" do

--- a/src/schedule.cr
+++ b/src/schedule.cr
@@ -31,7 +31,7 @@ class Skedjewel::Schedule
   private def minute_match?(time)
     if @schedule_minute == "**"
       true
-    elsif @schedule_hour == "**" && @schedule_minute.matches?(MODULUS_REGEX)
+    elsif @schedule_minute.matches?(MODULUS_REGEX)
       minute_modulo_match?(time)
     else
       time.minute == integer_minute


### PR DESCRIPTION
Although it's probably not a very common use case, if someone wants to do "02:%5" (to run every 5 minutes in hour 2) or "%2:%10" (to run every 10 minutes in even hours), then they should be able to.