### PR TITLE
[refactor] Use local time in the specified time zone [SKED-9]

### DIFF
--- a/spec/schedule_spec.cr
+++ b/spec/schedule_spec.cr
@@ -4,9 +4,10 @@ Spectator.describe Skedjewel::Schedule do
   subject(schedule) { Skedjewel::Schedule.new(schedule_string) }
 
   describe "#matches?" do
+    let(location) { Time::Location.load(time_zone) }
+
     context "when the schedule time zone has a negative UTC offset (America/Chicago)" do
       let(time_zone) { "America/Chicago" }
-      let(location) { Time::Location.load(time_zone) }
 
       before_each do
         Skedjewel.config = Skedjewel::Config.new({"time_zone" => time_zone})
@@ -15,23 +16,16 @@ Spectator.describe Skedjewel::Schedule do
       context "when the schedule string is 23:59" do
         let(schedule_string) { "23:59" }
 
-        context "when the checked time is 23:59 in America/Chicago as a UTC time" do
-          let(time) do
-            utc_offset = (
-              Time.local(Time::Location.load(time_zone)).zone.offset /
-              (60 * 60)
-            ).to_i
-
-            Time.utc(2022, 11, 5, -1 * utc_offset - 1, 59, 0)
-          end
+        context "when the checked time is local time 23:59" do
+          let(time) { Time.local(2025, 3, 16, 23, 59, 0, location: location) }
 
           it "returns true" do
             expect(schedule.matches?(time)).to eq(true)
           end
         end
 
-        context "when the checked time is 23:59:00Z" do
-          let(time) { Time.utc(2022, 11, 4, 23, 59, 0) }
+        context "when the checked time is local time 23:58" do
+          let(time) { Time.local(2025, 3, 16, 23, 58, 0, location: location) }
 
           it "returns false" do
             expect(schedule.matches?(time)).to eq(false)
@@ -42,23 +36,16 @@ Spectator.describe Skedjewel::Schedule do
       context "when the schedule string is 00:05" do
         let(schedule_string) { "00:05" }
 
-        context "when the checked time is 00:05 in America/Chicago as a UTC time" do
-          let(time) do
-            utc_offset = (
-              Time.local(Time::Location.load(time_zone)).zone.offset /
-              (60 * 60)
-            ).to_i
-
-            Time.utc(2022, 11, 4, -1 * utc_offset, 5, 10)
-          end
+        context "when the checked time is local time 00:05" do
+          let(time) { Time.local(2025, 3, 16, 0, 5, 0, location: location) }
 
           it "returns true" do
             expect(schedule.matches?(time)).to eq(true)
           end
         end
 
-        context "when the checked time is 00:06:00Z" do
-          let(time) { Time.utc(2022, 11, 4, 0, 6, 0) }
+        context "when the checked time is local time 00:06" do
+          let(time) { Time.local(2025, 3, 16, 0, 6, 0, location: location) }
 
           it "returns false" do
             expect(schedule.matches?(time)).to eq(false)
@@ -105,24 +92,24 @@ Spectator.describe Skedjewel::Schedule do
       context "when the schedule string is '**:%5'" do
         let(schedule_string) { "**:%5" }
 
-        context "when the checked time is UTC 00:15:29" do
-          let(time) { Time.utc(2025, 3, 15, 0, 15, 29) }
+        context "when the checked time is local time 00:15:29" do
+          let(time) { Time.local(2025, 3, 16, 0, 15, 29, location: location) }
 
           it "returns true" do
             expect(schedule.matches?(time)).to eq(true)
           end
         end
 
-        context "when the checked time is UTC 13:25:48" do
-          let(time) { Time.utc(2025, 3, 15, 13, 25, 48) }
+        context "when the checked time is local time 13:25:48" do
+          let(time) { Time.local(2025, 3, 15, 13, 25, 48, location: location) }
 
           it "returns true" do
             expect(schedule.matches?(time)).to eq(true)
           end
         end
 
-        context "when the checked time is UTC 13:26:48" do
-          let(time) { Time.utc(2025, 3, 15, 13, 26, 48) }
+        context "when the checked time is local time 13:26:48" do
+          let(time) { Time.local(2025, 3, 15, 13, 26, 48, location: location) }
 
           it "returns false" do
             expect(schedule.matches?(time)).to eq(false)
@@ -213,23 +200,16 @@ Spectator.describe Skedjewel::Schedule do
       context "when the schedule string is 01:30" do
         let(schedule_string) { "01:30" }
 
-        context "when the checked time is 01:30 in Europe/Moscow as a UTC time" do
-          let(time) do
-            utc_offset = (
-              Time.local(Time::Location.load(time_zone)).zone.offset /
-              (60 * 60)
-            ).to_i
-
-            Time.utc(2022, 11, 4, 25 - utc_offset, 30, 0)
-          end
+        context "when the checked time is local time 01:30" do
+          let(time) { Time.local(2025, 3, 16, 1, 30, 0, location: location) }
 
           it "returns true" do
             expect(schedule.matches?(time)).to eq(true)
           end
         end
 
-        context "when the checked time is 01:30:00Z" do
-          let(time) { Time.utc(2022, 11, 5, 1, 30, 0) }
+        context "when the checked time is local time 02:30" do
+          let(time) { Time.local(2025, 3, 16, 2, 30, 0, location: location) }
 
           it "returns false" do
             expect(schedule.matches?(time)).to eq(false)

--- a/src/schedule.cr
+++ b/src/schedule.cr
@@ -3,7 +3,7 @@ class Skedjewel::Schedule
 
   @schedule_hour : String
   @schedule_minute : String
-  @utc_scheduled_integer_hour : Int32 | Nil
+  @scheduled_integer_hour : Int32 | Nil
   @integer_minute : Int32 | Nil
 
   def initialize(schedule_string)
@@ -20,7 +20,7 @@ class Skedjewel::Schedule
     elsif @schedule_hour.matches?(MODULUS_REGEX)
       hour_modulo_match?(time)
     else
-      time.to_utc.hour == utc_scheduled_integer_hour
+      time.hour == scheduled_integer_hour
     end
   end
 
@@ -47,8 +47,8 @@ class Skedjewel::Schedule
     (actual_time_unit % modulus) == 0
   end
 
-  private def utc_scheduled_integer_hour
-    @utc_scheduled_integer_hour ||= (@schedule_hour.to_i - schedule_time_zone_offset_hours) % 24
+  private def scheduled_integer_hour
+    @scheduled_integer_hour ||= @schedule_hour.to_i
   end
 
   private def schedule_time_zone_offset_hours

--- a/src/task.cr
+++ b/src/task.cr
@@ -6,6 +6,7 @@ class Skedjewel::Task
   def initialize(job_name : String, schedule_string, runner : Skedjewel::Runner)
     @job_name = job_name
     @schedule = Skedjewel::Schedule.new(schedule_string)
+    @schedule_time_location = Time::Location.load(Skedjewel.config.time_zone)
     @runner = runner
   end
 
@@ -20,7 +21,7 @@ class Skedjewel::Task
   end
 
   def should_run?
-    @schedule.matches?(Time.local)
+    @schedule.matches?(Time.local(@schedule_time_location))
   end
 
   private def resource_key(time)


### PR DESCRIPTION
... rather than subtracting the UTC offset, which seems to be needless complication, in both the application code and specs.