### PR TITLE
Specify 'skedjewel' as the name in 'shard.yml'

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: shards
+name: skedjewel
 version: 0.0.16
 
 dependencies:


### PR DESCRIPTION
It should always have been this way, I think. Doing it now.