### PR TITLE
Support offsets in modulo schedule notation [SKED-7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Support scheduling a job every X hours.
 - Support minute modulus even if hour is not `**`.
+- Support offsets in modulo schedule notation.
 
 ### Docs
 - Make README release title headings h2s (not h1s).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ jobs:
   DataMonitors::Launcher: '**:07' # hourly at 7 minutes after
   SendLogReminderEmails: '**:**' # every minute
   CapturePgHeroQueryStats: '**:%5' # every 5 minutes
+  CollectRedisMetrics: '**:%10+2' # every 10 minutes, with an offset of 2 (2, 12, 22, ...)
   CapturePgHeroQueryStats: '%2:07' # every 2 hours at 7 minutes after the hour
+  CapturePgHeroQueryStats: '%2+1:56' # every 2 hours (in odd hours) at 56 minutes after the hour
   TruncateTables: '04:58' # daily at 4:58am Central Time
 ```
 

--- a/spec/schedule_spec.cr
+++ b/spec/schedule_spec.cr
@@ -117,6 +117,46 @@ Spectator.describe Skedjewel::Schedule do
         end
       end
 
+      context "when the schedule string is '**:%10+2'" do
+        let(schedule_string) { "**:%10+2" }
+
+        context "when the checked time is local time 08:22" do
+          let(time) { Time.local(2025, 3, 16, 8, 22, 0, location: location) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is local time 08:27" do
+          let(time) { Time.local(2025, 3, 16, 8, 27, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+      end
+
+      context "when the schedule string is '%2+1:17'" do
+        let(schedule_string) { "%2+1:17" }
+
+        context "when the checked time is local time 15:17" do
+          let(time) { Time.local(2025, 3, 16, 15, 17, 0, location: location) }
+
+          it "returns true" do
+            expect(schedule.matches?(time)).to eq(true)
+          end
+        end
+
+        context "when the checked time is local time 16:17" do
+          let(time) { Time.local(2025, 3, 16, 16, 17, 0, location: location) }
+
+          it "returns false" do
+            expect(schedule.matches?(time)).to eq(false)
+          end
+        end
+      end
+
       context "when the schedule string is '02:%5'" do
         let(schedule_string) { "02:%5" }
 


### PR DESCRIPTION
This will help to avoid clustering on the hour and other even divisions of 60 minutes.