### PR TITLE
Restrict GitHub Actions token permissions [DEV-225]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: write # Permit 'write' (which also includes 'read') to upload assets to release.
+
 jobs:
   build_and_upload_linux_binary:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.0.18 - 2025-03-26
+- Restrict GitHub Actions token permissions.
+
 ## v0.0.17 - 2025-03-16
 - Support scheduling a job every X hours.
 - Support minute modulus even if hour is not `**`.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: skedjewel
-version: 0.0.17
+version: 0.0.18
 
 dependencies:
   memoization:


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

This should limit the surface area for attacks in the event of some sort of compromise.