### PR TITLE
Stop building for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,3 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: skedjewel-${{ github.ref_name }}-linux
-
-  build_and_upload_macos_binary:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
-      - name: Build
-        run: shards build --production --release --no-debug
-      - name: Check version matches tag
-        run: "[[ \"v$(bin/skedjewel --version)\" == ${{ github.ref_name }} ]] || exit 1"
-      - name: Move and rename binary
-        run: mv bin/skedjewel ./skedjewel-${{ github.ref_name }}-darwin
-      - name: Upload release binary
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: skedjewel-${{ github.ref_name }}-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.0.0 - 2025-03-26
+- **BREAKING:** Stop building for macOS.
+
 ## v0.0.18 - 2025-03-26
 - Restrict GitHub Actions token permissions.
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,13 @@ clock: bin/skedjewel
 Now, you need to download the appropriate binary and put it in the `bin/` directory of your Rails
 app.
 
-Binaries are released for both MacOS and for Linux. The latest release binaries are available
-[here][latest-release].
+Binaries are released only for Linux. The latest release binaries are available [here][latest-release].
 
 [latest-release]: https://github.com/davidrunger/skedjewel/releases/latest
 
 ## In development
 
-On your development machine, you can manually download the appropriate binary and put it in the
-`bin/` directory of your Rails project.
+On your development machine (if you are using Linux), you can manually download the appropriate binary and put it in the `bin/` directory of your Rails project.
 
 You'll also want to add `/bin/skedjewel` to your repository's `.gitignore` file.
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: skedjewel
-version: 0.0.18
+version: 1.0.0
 
 dependencies:
   memoization:


### PR DESCRIPTION
Since I don't use macOS for development anymore, I can't really verify that these releases are working as expected.

Part of my motivation for this change: the macOS builds also don't seem to be running anymore. I am guessing that maybe the `macos-11` runner has been decommissioned or something. I could upgrade to a more recent macos runner, but, like I say, I wouldn't really be able to verify it, so I'm just removing the macOS builds altogether.