### PR TITLE
Specify commits (not loose versions) for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '04:04'
+      timezone: America/Chicago

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
+        uses: crystal-lang/install-crystal@cdf26dcd488490c9939e9d4d62cab169c9e4f20d # v1.8.2
+
       - name: Install shards
         run: shards install
+
       - name: Build exe/skedjewel.cr
         run: crystal build exe/skedjewel.cr
+
       - name: Run tests
         run: crystal spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,20 @@ jobs:
     container:
       image: crystallang/crystal:latest-alpine
     steps:
-      - uses: actions/checkout@v4
+      - name: Download source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Build
         run: shards build --production --release --no-debug --static
+
       - name: Check version matches tag
         run: "[[ \"v$(bin/skedjewel --version)\" == ${{ github.ref_name }} ]] || exit 1"
+
       - name: Move and rename
         run: mv bin/skedjewel ./skedjewel-${{ github.ref_name }}-linux
+
       - name: Upload release binary
-        uses: shogo82148/actions-upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@d22998fda4c1407f60d1ab48cd6fe67f360f34de # v1.8.0
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: skedjewel-${{ github.ref_name }}-linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Internal
+- Specify commits (not loose versions) for GitHub Actions.
+
 ## v1.0.0 - 2025-03-26
 - **BREAKING:** Stop building for macOS.
 


### PR DESCRIPTION
This should lessen the risk of attacks such as this: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised .

The comments with the version tags, in conjunction with the `.github/dependabot.yml` config added in this PR, allow Dependabot to update the commits, so we can continue to enjoy using the ~latest version of the actions, but in a more controlled way that is at least somewhat less susceptible to supply chain attacks and with the ability to review the diffs.