### PR TITLE
[release] Install Crystal w/ crystal-lang/install-crystal action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Download source
+      - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Crystal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,12 @@ permissions:
 jobs:
   build_and_upload_linux_binary:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:latest-alpine
     steps:
-      - name: Download source
+      - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@cdf26dcd488490c9939e9d4d62cab169c9e4f20d # v1.8.2
 
       - name: Build
         run: shards build --production --release --no-debug --static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## v1.1.0 - 2025-03-27
 ### Internal
 - Specify commits (not loose versions) for GitHub Actions.
+- Install Crystal for release via `crystal-lang/install-crystal` action, rather than using a Crystal Docker image.
 
 ## v1.0.0 - 2025-03-26
 - **BREAKING:** Stop building for macOS.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: skedjewel
-version: 1.0.0
+version: 1.1.0
 
 dependencies:
   memoization:


### PR DESCRIPTION
... rather than using a Crystal Docker image.

This documentation https://crystal-lang.org/reference/1.15/guides/ci/gh-actions.html#using-the-official-docker-image links to this post https://forum.crystal-lang.org/t/github-action-to-install-crystal-and-shards-unified-ci-across-linux-macos-and-windows/2837 that cites some advantages of using the GitHub Action.

One supposed advantage is that the GitHub action is faster?, though I don't know why that would be the case, and I'm skeptical it's true. (The cited source is no longer accessible.)

One advantage that I think is real is that it allows us to us the probably more up-to-date and more "official" and supported-by-GitHub GitHub runner image as a starting point.

We were already using the `crystal-lang/install-crystal` GitHub Action to install Crystal in `ci.yml`. This change updates us to do the same in `release.yml`.

Also, prepare for release as v1.1.0 (so that we can test that the release GitHub Action still works).

Also, change "Download source" to "Check out code" to better align and hint at the name of the underlying action.