### PR TITLE
[readme] Update outdated language referring to binary(s) to singular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Docs
+- [readme] Update outdated language referring to binary(s) from plural to singular.
+
 ## v1.1.0 - 2025-03-27
 ### Internal
 - Specify commits (not loose versions) for GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ Start by adding something like this to your `Procfile`:
 clock: bin/skedjewel
 ```
 
-Now, you need to download the appropriate binary and put it in the `bin/` directory of your Rails
-app.
-
-Binaries are released only for Linux. The latest release binaries are available [here][latest-release].
+Now, you need to download the appropriate compiled binary and put it in the `bin/` directory of your Rails app. Binaries are released only for Linux. The latest release binary is available [here][latest-release].
 
 [latest-release]: https://github.com/davidrunger/skedjewel/releases/latest
 


### PR DESCRIPTION
Since #70, we now only release a single binary per release, for Linux.

Also, combine two pretty related paragraphs into a single paragraph.