### PR TITLE
Break out jobs by Rails environment in which they should run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## v2.0.0 - 2025-03-30
+- **BREAKING:** In the YAML config, the `jobs` key has been renamed to `jobs_by_rails_env`, and jobs must now be provided nested under a key corresponding to the Rails environment in which the job(s) should run. Use a key of `all` for jobs that should run in all Rails environments. See the README for an example.
+
 ### Docs
 - [readme] Update outdated language referring to binary(s) from plural to singular.
 - [readme] Add snippet showing how to build skedjewel into Docker image.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ config:
   sidekiq_redis_db: 1
   time_zone: America/Chicago
 
-jobs:
-  DataMonitors::Launcher: '**:07' # hourly at 7 minutes after
-  SendLogReminderEmails: '**:**' # every minute
-  CapturePgHeroQueryStats: '**:%5' # every 5 minutes
-  CollectRedisMetrics: '**:%10+2' # every 10 minutes, with an offset of 2 (2, 12, 22, ...)
-  CapturePgHeroQueryStats: '%2:07' # every 2 hours at 7 minutes after the hour
-  CapturePgHeroQueryStats: '%2+1:56' # every 2 hours (in odd hours) at 56 minutes after the hour
-  TruncateTables: '04:58' # daily at 4:58am Central Time
+jobs_by_rails_env:
+  all:
+    DataMonitors::Launcher: '**:07' # hourly at 7 minutes after
+    TruncateTables: '**:**' # every minute
+  production:
+    CheckLinks::LaunchPageFetches: '04:16' # daily at 4:16am in configured time zone
+    CollectRedisMetrics: '**:%5' # every 5 minutes
+    PgHero::CaptureQueryStats: '**:%10+2' # every 10 minutes, with an offset of 2 (2, 12, 22, ...)
+    PgHero::CaptureQueryStats: '%2:07' # every 2 hours at 7 minutes after the hour
+    PgHero::CaptureQueryStats: '%2+1:56' # every 2 hours (in odd hours) at 56 minutes after the hour
 ```
 
 You can print the Skedjewel version:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: skedjewel
-version: 1.1.0
+version: 2.0.0
 
 dependencies:
   memoization:

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -17,7 +17,7 @@ class Skedjewel::Runner
       )
     @tasks = [] of Skedjewel::Task
     @tasks =
-      jobs_for_env.map do |(job_name, schedule_string)|
+      jobs_for_env.map do |job_name, schedule_string|
         Skedjewel::Task.new(
           job_name,
           schedule_string,

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -12,8 +12,8 @@ class Skedjewel::Runner
   def initialize
     jobs_by_rails_env = Skedjewel.parsed_config_file["jobs_by_rails_env"].as_h
     jobs_for_env =
-      (to_hash(jobs_by_rails_env["all"]?) || {} of String => String).merge(
-        to_hash(jobs_by_rails_env[ENV.fetch("RAILS_ENV", "development")]?) || {} of String => String
+      (to_hash(jobs_by_rails_env["all"]?)).merge(
+        to_hash(jobs_by_rails_env[ENV.fetch("RAILS_ENV", "development")]?)
       )
     @tasks = [] of Skedjewel::Task
     @tasks =
@@ -26,10 +26,10 @@ class Skedjewel::Runner
       end
   end
 
-  # Helper method to convert YAML::Any? to Array(Hash(String, String)).
+  # Helper method to convert YAML::Any? to Hash(String, String).
   private def to_hash(yaml_any : YAML::Any?) : Hash(String, String)
     if yaml_any
-      yaml_any.as_h.transform_keys(&.to_s).transform_values(&.to_s).as(Hash(String, String)) # Convert to hash with string keys/values
+      yaml_any.as_h.transform_keys(&.to_s).transform_values(&.to_s).as(Hash(String, String))
     else
       {} of String => String
     end

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -10,15 +10,29 @@ class Skedjewel::Runner
   @@began_exit_process = false
 
   def initialize
+    jobs_by_rails_env = Skedjewel.parsed_config_file["jobs_by_rails_env"].as_h
+    jobs_for_env =
+      (to_hash(jobs_by_rails_env["all"]?) || {} of String => String).merge(
+        to_hash(jobs_by_rails_env[ENV.fetch("RAILS_ENV", "development")]?) || {} of String => String
+      )
     @tasks = [] of Skedjewel::Task
     @tasks =
-      Skedjewel.parsed_config_file["jobs"].as_h.map do |job_name, schedule_string|
+      jobs_for_env.map do |(job_name, schedule_string)|
         Skedjewel::Task.new(
-          job_name.as_s,
-          schedule_string.as_s,
+          job_name,
+          schedule_string,
           self,
         )
       end
+  end
+
+  # Helper method to convert YAML::Any? to Array(Hash(String, String)).
+  private def to_hash(yaml_any : YAML::Any?) : Hash(String, String)
+    if yaml_any
+      yaml_any.as_h.transform_keys(&.to_s).transform_values(&.to_s).as(Hash(String, String)) # Convert to hash with string keys/values
+    else
+      {} of String => String
+    end
   end
 
   def run
@@ -45,11 +59,10 @@ class Skedjewel::Runner
 
       sleep(
         Time::Span.new(
-          nanoseconds:
-            seconds_to_nanoseconds(
-              seconds_until_next_minute(Time.local) +
-                0.001, # Add a millisecond to ensure we go into the next minute.
-            ),
+          nanoseconds: seconds_to_nanoseconds(
+            seconds_until_next_minute(Time.local) +
+            0.001, # Add a millisecond to ensure we go into the next minute.
+          ),
         )
       )
     end


### PR DESCRIPTION
This makes it possible, for example, to run certain jobs only in production (not in development).