### PR TITLE
Print Crystal version used for compilation in '--version' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Print Crystal version that was used for compilation in the `--version` output.
+
 ## v2.0.0 - 2025-03-30
 - **BREAKING:** In the YAML config, the `jobs` key has been renamed to `jobs_by_rails_env`, and jobs must now be provided nested under a key corresponding to the Rails environment in which the job(s) should run. Use a key of `all` for jobs that should run in all Rails environments. See the README for an example.
 

--- a/exe/skedjewel.cr
+++ b/exe/skedjewel.cr
@@ -6,7 +6,7 @@ STDOUT.flush_on_newline = true
 
 OptionParser.parse do |parser|
   parser.on "-v", "--version", "Show version" do
-    puts(Skedjewel::VERSION)
+    puts("Skedjewel #{Skedjewel::VERSION} (compiled with Crystal #{Crystal::VERSION})")
     exit
   end
 end


### PR DESCRIPTION
I have no particular reason for doing this, apart from the fact that it seems like somewhat important and potentially useful info.